### PR TITLE
Allows StataPush to run a do file so that you'll receive a notification if the do file runs into an error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,13 @@ statapush is pretty simple to use. Just place the snippet below (with your API t
 
 	statapush, token(<TOKEN>) userid(<USER KEY>) message(<MESSAGE>)
 
-<<<<<<< HEAD
 statapush can also run a do file by optionally including the file path to the do file. Doing so will enable you to receive a notification even when your do file contains an error.
-=======
+
 If you'd like to use Pushbullet, simply add the option
 
-    statapush, token(<TOKEN>) userid(<USER KEY>) message(<MESSAGE>) provider("pushbullet")
+    statapush, token(<TOKEN>) userid(<USER KEY>) message(<MESSAGE>) provider(pushbullet)
 
 statapush can also run a do file by optionally including a do file. Doing so will enable you to receive a notification when you do file completes.
->>>>>>> develop
 
     statapush using <FILENAME>, token(<TOKEN>) userid(<USER KEY>) message(<MESSAGE>)
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # statapush
-statapush is a simple Stata module for sending push notifications. It is designed to be used when you have an analysis that will take a long time to process; the module will let you know your code has finished running via an alert on your mobile device. statapush relies on the push notification service [Pushover](https://pushover.net). It was inspired by the R package [pushoverr](https://github.com/briandconnelly/pushoverr). 
+statapush is a simple Stata module for sending push notifications. It is designed to be used when you have an analysis that will take a long time to process; the module will let you know your code has finished running via an alert on your mobile device. statapush relies on the push notification service [Pushover](https://pushover.net) or [Pushbullet](https://www.pushbullet.com). It was inspired by the R package [pushoverr](https://github.com/briandconnelly/pushoverr). 
 
 ###Prerequisites
 
 1. **Stata**: statapush should be compatible with Stata v12.1+. While it may be compatible with earlier versions, it has not been tested in those environments.
 2. **cURL**:  statapush requires [cURL](https haxx.se/download.html), an open source command line tool and library. cURL is installed by default on most computers using Mac OS and Unix, but likely requires manual installation by Windows OS users.
-3. **Pushover**:  statapush requires users to sign up for a free [Pushover](https://pushover.net) account. Upon creating an account, make note of your user key and register a new application. Choose any name for the application (e.g., StataPush) and select “Application” under the “Type” dropdown. Make note of the API token associated with this application. You will also need to install the Pushover [client](https://pushover.net/clients) on your device (Android, iOS, or Desktop). The client is available for a free seven-day trial, after which users must pay a one-time $4.99 fee per device.
+3. **Pushover** or **Pushbullet**:  statapush requires users to sign up for a free [Pushover](https://pushover.net) account or [Pushbullet](https://www.pushbullet.com) account. For Pushover, upon creating an account, make note of your user key and register a new application. Choose any name for the application (e.g., StataPush) and select “Application” under the “Type” dropdown. Make note of the API token associated with this application. You will also need to install the Pushover [client](https://pushover.net/clients) on your device (Android, iOS, or Desktop). The client is available for a free seven-day trial, after which users must pay a one-time $4.99 fee per device. For Pushbullet, upon creating an account, you can create an API token under [account settings](https://www.pushbullet.com/#settings/account) by clicking "Create Access Token." You'll use this token and your username with statapush. The [Pushbullet clients](https://www.pushbullet.com/apps) are free to use for notification mirroring. 
 
 ###Installation Options
 
@@ -26,6 +26,10 @@ statapush is a simple Stata module for sending push notifications. It is designe
 statapush is pretty simple to use. Just place the snippet below (with your API token, user key, and message) at the point you want Stata to generate the push notification in your do file. Then run the file.
 
 	statapush, token(<TOKEN>) userid(<USER KEY>) message(<MESSAGE>)
+
+If you'd like to use Pushbullet, simply add the option
+
+    statapush, token(<TOKEN>) userid(<USER KEY>) message(<MESSAGE>) provider("pushbullet")
 
 statapush can also run a do file by optionally including a do file. Doing so will enable you to receive a notification when you do file completes.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can also set your default preferences so you don't need to include your API 
 
     statapushpref, provider("pushover") userid(<USER KEY>) token(<TOKEN>)
 
-You preferences are saved in a file called statapushpref.ado along with your other Stata packages.
+You preferences are saved in a file called statapushpref.do along with your other Stata packages.
 
 ###Bug Reports
 

--- a/README.md
+++ b/README.md
@@ -27,13 +27,11 @@ statapush is pretty simple to use. Just place the snippet below (with your API t
 
 	statapush, token(<TOKEN>) userid(<USER KEY>) message(<MESSAGE>)
 
-statapush can also run a do file by optionally including the file path to the do file. Doing so will enable you to receive a notification even when your do file contains an error.
-
 If you'd like to use Pushbullet, simply add the option
 
     statapush, token(<TOKEN>) userid(<USER KEY>) message(<MESSAGE>) provider(pushbullet)
 
-statapush can also run a do file by optionally including a do file. Doing so will enable you to receive a notification when you do file completes.
+statapush can also run a do file by optionally including the file path to the do file. Doing so will enable you to receive a notification even when your do file contains an error.
 
     statapush using <FILENAME>, token(<TOKEN>) userid(<USER KEY>) message(<MESSAGE>)
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you'd like to use Pushbullet, simply add the option
 
 statapush can also run a do file by optionally including a do file. Doing so will enable you to receive a notification when you do file completes.
 
-    statapush using "<FILENAME>", token(<TOKEN>) userid(<USER KEY>) message(<MESSAGE>)
+    statapush using <FILENAME>, token(<TOKEN>) userid(<USER KEY>) message(<MESSAGE>)
 
 You can also set your default preferences so you don't need to include your API token and user ID every time.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ statapush is pretty simple to use. Just place the snippet below (with your API t
 
 	statapush, token(<TOKEN>) userid(<USER KEY>) message(<MESSAGE>)
 
-statapush can also run a do file by optionally including a do file. Doing so will enable you to receive a notification when you do file completes.
+statapush can also run a do file by optionally including the file path to the do file. Doing so will enable you to receive a notification even when your do file contains an error.
 
     statapush using "<FILENAME>", token(<TOKEN>) userid(<USER KEY>) message(<MESSAGE>)
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ statapush can also run a do file by optionally including a do file. Doing so wil
 
     statapush using "<FILENAME>", token(<TOKEN>) userid(<USER KEY>) message(<MESSAGE>)
 
+You can also set your default preferences so you don't need to include your API token and user ID every time.
+
+    statapushpref, provider("pushover") userid(<USER KEY>) token(<TOKEN>)
+
+You preferences are saved in a file called statapushpref.ado along with your other Stata packages.
+
 ###Bug Reports
 
 Please [let me know](https://github.com/wschpero/statapush/issues) if you encounter any issues. Enjoy!

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ statapush can also run a do file by optionally including a do file. Doing so wil
 
 You can also set your default preferences so you don't need to include your API token and user ID every time.
 
-    statapushpref, provider("pushover") userid(<USER KEY>) token(<TOKEN>)
+    statapushpref, provider(pushover) userid(<USER KEY>) token(<TOKEN>)
 
 You preferences are saved in a file called statapushconfig.ado along with your other Stata packages.
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ statapush is pretty simple to use. Just place the snippet below (with your API t
 
 	statapush, token(<TOKEN>) userid(<USER KEY>) message(<MESSAGE>)
 
+statapush can also run a do file by optionally including a do file. Doing so will enable you to receive a notification when you do file completes.
+
+    statapush using "<FILENAME>", token(<TOKEN>) userid(<USER KEY>) message(<MESSAGE>)
+
 ###Bug Reports
 
 Please [let me know](https://github.com/wschpero/statapush/issues) if you encounter any issues. Enjoy!

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can also set your default preferences so you don't need to include your API 
 
     statapushpref, provider("pushover") userid(<USER KEY>) token(<TOKEN>)
 
-You preferences are saved in a file called statapushpref.do along with your other Stata packages.
+You preferences are saved in a file called statapushconfig.ado along with your other Stata packages.
 
 ###Bug Reports
 

--- a/statapush.ado
+++ b/statapush.ado
@@ -64,6 +64,6 @@ program define _statapushprefgrab, rclass
     quietly include "`r(fn)'"
     return local provider "`default_provider'"
     return local token    "``default_provider'_token'"
-    return local user_id  "``default_provider'_userid'"
+    return local userid  "``default_provider'_userid'"
 end
 

--- a/statapush.ado
+++ b/statapush.ado
@@ -60,7 +60,7 @@ end
 
 capture program drop _statapushprefgrab
 program define _statapushprefgrab, rclass
-    findfile statapushconfig.ado
+    quietly findfile statapushconfig.ado
     quietly include "`r(fn)'"
     return local provider "`default_provider'"
     return local token    "``default_provider'_token'"

--- a/statapush.ado
+++ b/statapush.ado
@@ -1,20 +1,40 @@
+
 /*
-
 statapush: Stata module for sending push notifications
-
 Author: William L. Schpero
 Contact: william.schpero@yale.edu
 Date: 020216
 Version: 1.1
-
 */
 
-program statapush
+capture program drop statapush
+program define statapush
+    version 12.1
+    syntax [using/], Token(string) Userid(string) Message(string)
 
-	version 12.1
-	
-	syntax , Token(string) Userid(string) Message(string)
-	quietly !curl -s -F "token=`token'" -F "user=`userid'" -F "title=statapush" -F "message=`message'" https://api.pushover.net/1/messages.json
-	display "Notification pushed at `c(current_time)'"
+    if "`using'" != "" {
+        capture noisily do "`using'"
+        if _rc == 0 {
+            _statapush, t(`token') u(`userid') m(`message')
+        }
+        else {
+            _statapush, t(`token') u(`userid') m("There's an error")
+        }
+    }
+    else {
+        _statapush, t(`token') u(`userid') m(`message')
+    }
 
 end
+
+capture program drop _statapush
+program define _statapush
+    version 12.1
+    syntax [using/], Token(string) Userid(string) Message(string)
+    quietly !curl -s -F "token=`token'" -F "user=`userid'" -F "title=statapush" -F "message=`message'" https://api.pushover.net/1/messages.json
+    display "Notification pushed at `c(current_time)'"
+end
+
+/*
+ 
+*/

--- a/statapush.ado
+++ b/statapush.ado
@@ -42,14 +42,6 @@ program define _statapush
     display "Notification pushed at `c(current_time)'"
 end
 
-capture program drop _statapush
-program define _statapush
-    version 12.1
-    syntax [using/], Token(string) Userid(string) Message(string)
-    quietly !curl -s -F "token=`token'" -F "user=`userid'" -F "title=statapush" -F "message=`message'" https://api.pushover.net/1/messages.json
-    display "Notification pushed at `c(current_time)'"
-end
-
 capture program drop _statapushbullet
 program define _statapushbullet
     version 12.1

--- a/statapush.ado
+++ b/statapush.ado
@@ -60,7 +60,7 @@ end
 
 capture program drop _statapushprefgrab
 program define _statapushprefgrab, rclass
-    findfile statapushpref.ado
+    findfile statapushconfig.ado
     quietly include "`r(fn)'"
     return local provider "`default_provider'"
     return local token    "``default_provider'_token'"

--- a/statapush.ado
+++ b/statapush.ado
@@ -28,7 +28,7 @@ program define statapush
         local pushcmd "_statapushbullet"
     }
     else {
-        display as error "Invalid provider: `provider'. Need to supply pushover or pushbullet."
+        display as error "Invalid provider: `provider'. Need to use 'pushover' or 'pushbullet'."
         exit 198
     }
 

--- a/statapush.ado
+++ b/statapush.ado
@@ -58,18 +58,6 @@ program define _statapushbullet
     display "Notification pushed at `c(current_time)'"
 end
 
-capture program drop statapushpref
-program define statapushpref
-    version 12.1
-    syntax, Provider(string) Token(string) Userid(string)
-    findfile statapushpref.ado
-    file open statapushpref_ado using "`r(fn)'", write append
-    file write statapushpref_ado "local default_provider `provider'" _n
-    file write statapushpref_ado "local `provider'_token `token'"    _n
-    file write statapushpref_ado "local `provider'_userid `userid'"  _n
-    file close statapushpref_ado
-end
-
 capture program drop _statapushprefgrab
 program define _statapushprefgrab, rclass
     findfile statapushpref.ado

--- a/statapush.ado
+++ b/statapush.ado
@@ -18,7 +18,7 @@ program define statapush
             _statapush, t(`token') u(`userid') m(`message')
         }
         else {
-            _statapush, t(`token') u(`userid') m("There's an error")
+            _statapush, t(`token') u(`userid') m("There's an error in `using'.")
         }
     }
     else {

--- a/statapush.pkg
+++ b/statapush.pkg
@@ -10,4 +10,4 @@ d
 f statapush.ado
 f statapush.sthlp
 f statapushpref.ado
-f statapushpref.do
+f statapushconfig.ado

--- a/statapush.pkg
+++ b/statapush.pkg
@@ -9,3 +9,5 @@ d Support: william.schpero@yale.edu
 d
 f statapush.ado
 f statapush.sthlp
+f statapushpref.ado
+f statapushpref.do

--- a/statapush.sthlp
+++ b/statapush.sthlp
@@ -6,7 +6,7 @@
 
 {title: Syntax}
 
-{p 4 8}{cmd:statapush} [{cmd:using} {it:{help filename}}], {cmdab:t:oken}({it:string}) {cmdab:u:serid}({it:string}) {cmdab:m:essage}({it:string})
+{p 4 8}{cmd:statapush} [{cmd:using} {it:{help filename}}], {cmdab:t:oken}({it:string}) {cmdab:u:serid}({it:string}) {cmdab:m:essage}({it:string}) [{cmdab:p:rovider}({it:string})]
 
 {pstd}
 You may optionally include a do file to run in {it:filename}. Doing so will enable you to still get a notification if you code contains an error. You may enclose {it:filename} in double quotes and must do so if
@@ -35,6 +35,9 @@ You may optionally include a do file to run in {it:filename}. Doing so will enab
 {p 4 8}{cmdab:u:serid}({it:string}) Use this option to provide your Pushover user key.
 
 {p 4 8}{cmdab:m:essage}({it:string}) Use this option to specify the message you would like included in your push notification.
+
+{p 4 8}{bf:Note:} The following argument is not required.
+{p 4 8}{cmdab:m:essage}({it:string}) Use this option to specify the provider of the push notifications you'd like to use (Pushover or Pushbullet). By default, Pushover is used. Pass "pushbullet" to use Pushbullet.
 
 {title: Examples}
 

--- a/statapush.sthlp
+++ b/statapush.sthlp
@@ -6,7 +6,11 @@
 
 {title: Syntax}
 
-{p 4 8}{cmd:statapush}, {cmdab:t:oken}({it:string}) {cmdab:u:serid}({it:string}) {cmdab:m:essage}({it:string})
+{p 4 8}{cmd:statapush} [{cmd:using} {it:{help filename}}], {cmdab:t:oken}({it:string}) {cmdab:u:serid}({it:string}) {cmdab:m:essage}({it:string})
+
+{pstd}
+You may optionally include a do file to run in {it:filename}. Doing so will enable you to still get a notification if you code contains an error. You may enclose {it:filename} in double quotes and must do so if
+{it:filename} contains blanks or other special characters.
 
 {title: Description}
 

--- a/statapush.sthlp
+++ b/statapush.sthlp
@@ -18,13 +18,23 @@ You may optionally include a do file to run in {it:filename}. Doing so will enab
 
 {p 4 8}{cmd:statapush} requires cURL, an open source command line tool and library. cURL is installed by default on computers using Mac OS and Unix, but requires {browse "https://curl.haxx.se/download.html":manual installation} for Windows.
 
-{p 4 8}{cmd:statapush} also requires use of the push notification service Pushover.
+{p 4 8}{cmd:statapush} also requires use of the push notification service Pushover or Pushbullet.
+
+{p 4 8}{bf:For Pushover}
 
 {p 4 8}{bf:1.} Create a free {browse "https://pushover.net":Pushover} account and make note of your user key.
 
 {p 4 8}{bf:2.} Register a new Pushover application. Choose any name for the application (e.g., StataPush) and select "Application" under the "Type" dropdown. Make note of the API token associated with this application.
 
-{p 4 8}{bf:3.} Install the Pushover {browse "https://pushover.net/clients":client} on your device (Android, iOS, or Desktop). The client is available for a free seven-day trial, after which users must pay a one-time $4.99 fee per device.
+{p 4 8}{bf:3.} Install the Pushover {browse "https://pushover.net/clients":client} on your device (Android, iOS, or Desktop). The Pushover client is available for a free seven-day trial, after which users must pay a one-time $4.99 fee per device.
+
+{p 4 8}{bf:For Pushbullet}
+
+{p 4 8}{bf:1.} Create a free {browse "http://pushbullet.com/":Pushbullet} account.
+
+{p 4 8}{bf:2.} Create an API token under {browse "https://www.pushbullet.com/#settings/account":account settings} by clicking "Create Access Token."
+
+{p 4 8}{bf:3.} Install the Pushbullet {browse "https://www.pushbullet.com/apps":client} on your device (Android, iOS, or Desktop). The Pushover client is available for free.
 
 {title: Options}
 

--- a/statapush.sthlp
+++ b/statapush.sthlp
@@ -36,8 +36,9 @@ You may optionally include a do file to run in {it:filename}. Doing so will enab
 
 {p 4 8}{cmdab:m:essage}({it:string}) Use this option to specify the message you would like included in your push notification.
 
-{p 4 8}{bf:Note:} The following argument is not required.
-{p 4 8}{cmdab:m:essage}({it:string}) Use this option to specify the provider of the push notifications you'd like to use (Pushover or Pushbullet). By default, Pushover is used. Pass "pushbullet" to use Pushbullet.
+{p 4 8}{bf:Note:} The follow argument is not required.
+
+{p 4 8}{cmdab:p:rovider}({it:string}) Use this option to specify the provider of the push notifications you'd like to use (Pushover or Pushbullet). By default, Pushover is used. Pass "pushbullet" to use Pushbullet.
 
 {title: Examples}
 

--- a/statapushpref.ado
+++ b/statapushpref.ado
@@ -1,0 +1,11 @@
+capture program drop statapushpref
+program define statapushpref
+    version 12.1
+    syntax, Provider(string) Token(string) Userid(string)
+    findfile statapushpref.ado
+    file open statapushpref_ado using "`r(fn)'", write append
+    file write statapushpref_ado "local default_provider `provider'" _n
+    file write statapushpref_ado "local `provider'_token `token'"    _n
+    file write statapushpref_ado "local `provider'_userid `userid'"  _n
+    file close statapushpref_ado
+end

--- a/statapushpref.ado
+++ b/statapushpref.ado
@@ -3,13 +3,13 @@ program define statapushpref
     version 12.1
     syntax, Provider(string) Token(string) Userid(string)
     quietly findfile statapushconfig.ado
-    quietly file open statapushpref_ado using "`r(fn)'", write append
+    local statapushconfig "`r(fn)'"
+    quietly file open statapushpref_ado using "`statapushconfig'", write append
     quietly file write statapushpref_ado "local default_provider `provider'" _n
     quietly file write statapushpref_ado "local `provider'_token `token'"    _n
     quietly file write statapushpref_ado "local `provider'_userid `userid'"  _n
     quietly file close statapushpref_ado
     if _rc == 0 {
-        findfile statapushconfig.ado
-        display "Your preferences have been saved in `r(fn)'"
+        display as result "Your preferences have been saved in {browse `statapushconfig'}"
     }
 end

--- a/statapushpref.ado
+++ b/statapushpref.ado
@@ -2,10 +2,14 @@ capture program drop statapushpref
 program define statapushpref
     version 12.1
     syntax, Provider(string) Token(string) Userid(string)
-    findfile statapushconfig.ado
-    file open statapushpref_ado using "`r(fn)'", write append
-    file write statapushpref_ado "local default_provider `provider'" _n
-    file write statapushpref_ado "local `provider'_token `token'"    _n
-    file write statapushpref_ado "local `provider'_userid `userid'"  _n
-    file close statapushpref_ado
+    quietly findfile statapushconfig.ado
+    quietly file open statapushpref_ado using "`r(fn)'", write append
+    quietly file write statapushpref_ado "local default_provider `provider'" _n
+    quietly file write statapushpref_ado "local `provider'_token `token'"    _n
+    quietly file write statapushpref_ado "local `provider'_userid `userid'"  _n
+    quietly file close statapushpref_ado
+    if _rc == 0 {
+        findfile statapushconfig.ado
+        display "Your preferences have been saved in `r(fn)'"
+    }
 end

--- a/statapushpref.ado
+++ b/statapushpref.ado
@@ -2,7 +2,7 @@ capture program drop statapushpref
 program define statapushpref
     version 12.1
     syntax, Provider(string) Token(string) Userid(string)
-    findfile statapushpref.ado
+    findfile statapushpref.do
     file open statapushpref_ado using "`r(fn)'", write append
     file write statapushpref_ado "local default_provider `provider'" _n
     file write statapushpref_ado "local `provider'_token `token'"    _n

--- a/statapushpref.ado
+++ b/statapushpref.ado
@@ -2,7 +2,7 @@ capture program drop statapushpref
 program define statapushpref
     version 12.1
     syntax, Provider(string) Token(string) Userid(string)
-    findfile statapushpref.do
+    findfile statapushconfig.ado
     file open statapushpref_ado using "`r(fn)'", write append
     file write statapushpref_ado "local default_provider `provider'" _n
     file write statapushpref_ado "local `provider'_token `token'"    _n


### PR DESCRIPTION
Adds the ability to run a do file, which will you to receive a notification if there's an error in your code.

``` stata
* Install fork
net install statapush, from("https://raw.github.com/vikjam/statapush/master/") replace

* Create an example do file that has an error
file open example using "example-do.do", write
file write example "sysuse auto.dta" _n "regressx mpg price" _n
file close example

* Run statapush
statapush using "example-do.do", token(<INSERT API TOKEN>) userid(<INSERT USER KEY>) message(<INSERT MESSAGE>)
```
